### PR TITLE
Add yakui_wgpu::State::paint_with_encoder()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # yakui Changelog
+## 0.2.0 — ????-??-??
+* Add `yakui_wgpu::State::paint_with_encoder()` for encoding render commands to an existing `&mut wgpu::CommandEncoder`.
 
 ## 0.1.0 — 2022-07-17
 * Initial release.


### PR DESCRIPTION
* Add `yakui_wgpu::State::paint_with_encoder()` for encoding render commands to an existing `&mut wgpu::CommandEncoder`.
* Add yakui to the render pass label