### PR TITLE
Do not debug a vec of texture data

### DIFF
--- a/crates/yakui-core/src/paint/texture.rs
+++ b/crates/yakui-core/src/paint/texture.rs
@@ -1,12 +1,21 @@
 use glam::UVec2;
 
 /// A texture that is managed by yakui.
-#[derive(Debug)]
 pub struct Texture {
     format: TextureFormat,
     size: UVec2,
     data: Vec<u8>,
     pub(super) generation: u8,
+}
+
+impl std::fmt::Debug for Texture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Texture")
+            .field("format", &self.format)
+            .field("size", &self.size)
+            .field("generation", &self.generation)
+            .finish_non_exhaustive()
+    }
 }
 
 /// A texture format that yakui can manage.

--- a/crates/yakui-test/src/lib.rs
+++ b/crates/yakui-test/src/lib.rs
@@ -21,7 +21,7 @@ macro_rules! run {
     ($test:expr, $body:expr) => {
         let mut settings = ::yakui_test::insta::Settings::clone_current();
         settings.set_prepend_module_to_snapshot(false);
-        settings.bind_to_scope();
+        let _guard = settings.bind_to_scope();
 
         let test = $test;
         let mut state = ::yakui_test::yakui_core::State::new();

--- a/crates/yakui-test/src/lib.rs
+++ b/crates/yakui-test/src/lib.rs
@@ -21,7 +21,7 @@ macro_rules! run {
     ($test:expr, $body:expr) => {
         let mut settings = ::yakui_test::insta::Settings::clone_current();
         settings.set_prepend_module_to_snapshot(false);
-        settings.bind_to_thread();
+        settings.bind_to_scope();
 
         let test = $test;
         let mut state = ::yakui_test::yakui_core::State::new();


### PR DESCRIPTION
changes the debug on `Texture` to be a little easier to read. Since there *is* a `data` function, it seems like users should be able to log out the texture data if needed