### PR TITLE
Gamepad and Keyboard Navigation

### DIFF
--- a/crates/yakui-core/src/input/mod.rs
+++ b/crates/yakui-core/src/input/mod.rs
@@ -2,8 +2,10 @@
 
 mod input_state;
 mod mouse;
+mod navigation;
 
 pub use self::input_state::*;
 pub use self::mouse::*;
+pub use self::navigation::*;
 
 pub use keyboard_types::{Code as KeyCode, Modifiers};

--- a/crates/yakui-core/src/input/navigation.rs
+++ b/crates/yakui-core/src/input/navigation.rs
@@ -1,0 +1,16 @@
+/// Possible directions that a user can navigate in when using a gamepad or
+/// keyboard in a UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+pub enum NavDirection {
+    Down,
+    Up,
+    Left,
+    Right,
+
+    /// The next widget in the layout, used when the user presses tab.
+    Next,
+
+    /// The previous widget in the layout, used if the user presses shift+tab.
+    Previous,
+}

--- a/crates/yakui-core/src/widget.rs
+++ b/crates/yakui-core/src/widget.rs
@@ -9,7 +9,7 @@ use crate::dom::Dom;
 use crate::event::EventResponse;
 use crate::event::{EventInterest, WidgetEvent};
 use crate::geometry::{Constraints, FlexFit};
-use crate::input::InputState;
+use crate::input::{InputState, NavDirection};
 use crate::layout::LayoutDom;
 use crate::paint::PaintDom;
 use crate::WidgetId;
@@ -60,6 +60,15 @@ impl<'dom> PaintContext<'dom> {
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub struct EventContext<'dom> {
+    pub dom: &'dom Dom,
+    pub layout: &'dom LayoutDom,
+    pub input: &'dom InputState,
+}
+
+/// Information available to a widget when it is being queried for navigation.
+#[non_exhaustive]
+#[allow(missing_docs)]
+pub struct NavigateContext<'dom> {
     pub dom: &'dom Dom,
     pub layout: &'dom LayoutDom,
     pub input: &'dom InputState,
@@ -133,6 +142,13 @@ pub trait Widget: 'static + fmt::Debug {
     #[allow(unused)]
     fn event(&mut self, ctx: EventContext<'_>, event: &WidgetEvent) -> EventResponse {
         EventResponse::Bubble
+    }
+
+    /// Tell which widget should be navigated to if the user navigates in a
+    /// given direction.
+    #[allow(unused)]
+    fn navigate(&self, ctx: NavigateContext<'_>, dir: NavDirection) -> Option<WidgetId> {
+        None
     }
 }
 


### PR DESCRIPTION
Closes #7.

This is an early WIP. Navigation is done via a new widget method that lets widgets specify their connections: left, right, up, down, previous, and next.

Need to figure out how to bubble this information (should it be an event instead?) and how to render selection halos that reduces the burden of individual widgets.

We may want to decouple selection and focus, especially for things like sliders on controllers.