### PR TITLE
Clipping v2

### DIFF
--- a/crates/yakui-core/src/geometry/rect.rs
+++ b/crates/yakui-core/src/geometry/rect.rs
@@ -95,4 +95,15 @@ impl Rect {
     pub fn div_vec2(&self, size: Vec2) -> Self {
         Self::from_pos_size(self.pos / size, self.size / size)
     }
+
+    /// Returns a rectangle that fits this rectangle and the given rectangle.
+    #[inline]
+    pub fn constrain(mut self, other: Rect) -> Self {
+        let min = self.pos().max(other.pos());
+        let max = self.max().min(other.max());
+
+        self.set_pos(min);
+        self.set_max(max);
+        self
+    }
 }

--- a/crates/yakui-core/src/input/input_state.rs
+++ b/crates/yakui-core/src/input/input_state.rs
@@ -479,7 +479,14 @@ fn hit_test(_dom: &Dom, layout: &LayoutDom, coords: Vec2, output: &mut Vec<Widge
     for (id, _interest) in interest_mouse {
         let layout_node = layout.get(id).unwrap();
 
-        if layout_node.rect.contains_point(coords) {
+        let mut rect = layout_node.rect;
+        let mut node = layout_node;
+        while let Some(parent) = node.clipped_by {
+            node = layout.get(parent).unwrap();
+            rect = rect.constrain(node.rect);
+        }
+
+        if rect.contains_point(coords) {
             output.push(id);
         }
     }

--- a/crates/yakui-core/src/layout/mod.rs
+++ b/crates/yakui-core/src/layout/mod.rs
@@ -139,12 +139,20 @@ impl LayoutDom {
         // should be on top of the clip stack at this point.
         let clipping_enabled = self.clip_stack.last() == Some(&id);
 
+        // If this node enabled clipping, the next node under that is the node
+        // that clips this one.
+        let clipped_by = if clipping_enabled {
+            self.clip_stack.iter().nth_back(2).copied()
+        } else {
+            self.clip_stack.last().copied()
+        };
+
         self.nodes.insert_at(
             id.index(),
             LayoutDomNode {
                 rect: Rect::from_pos_size(Vec2::ZERO, size),
                 clipping_enabled,
-                clipped_by: self.clip_stack.last().copied(),
+                clipped_by,
                 event_interest,
             },
         );

--- a/crates/yakui-core/src/paint/paint_dom.rs
+++ b/crates/yakui-core/src/paint/paint_dom.rs
@@ -253,11 +253,7 @@ impl PaintDom {
         );
 
         if let Some(previous) = self.clip_stack.last() {
-            let min = unscaled.pos().max(previous.pos());
-            let max = unscaled.max().min(previous.max());
-
-            unscaled.set_pos(min);
-            unscaled.set_max(max);
+            unscaled = unscaled.constrain(*previous);
         }
 
         self.clip_stack.push(unscaled);

--- a/crates/yakui-widgets/src/widgets/render_textbox.rs
+++ b/crates/yakui-widgets/src/widgets/render_textbox.rs
@@ -69,6 +69,8 @@ impl Widget for RenderTextBoxWidget {
     }
 
     fn layout(&self, ctx: LayoutContext<'_>, input: Constraints) -> Vec2 {
+        ctx.layout.enable_clipping(ctx.dom);
+
         let fonts = ctx.dom.get_global_or_init(Fonts::default);
         let font = match fonts.get(&self.props.style.font) {
             Some(font) => font,
@@ -140,13 +142,6 @@ impl Widget for RenderTextBoxWidget {
         let text_layout = self.layout.borrow_mut();
         let layout_node = ctx.layout.get(ctx.dom.current()).unwrap();
 
-        // FIXME: For some reason, these values are negative sometimes!
-        let should_clip = layout_node.rect.size().x > 0.0 && layout_node.rect.size().y > 0.0;
-
-        if should_clip {
-            ctx.paint.push_clip(layout_node.rect);
-        }
-
         paint_text(
             &mut ctx,
             &self.props.style.font,
@@ -164,10 +159,6 @@ impl Widget for RenderTextBoxWidget {
             let mut rect = PaintRect::new(Rect::from_pos_size(cursor_pos, cursor_size));
             rect.color = Color::RED;
             ctx.paint.add_rect(rect);
-        }
-
-        if should_clip {
-            ctx.paint.pop_clip();
         }
     }
 }

--- a/crates/yakui-widgets/src/widgets/scrollable.rs
+++ b/crates/yakui-widgets/src/widgets/scrollable.rs
@@ -61,6 +61,8 @@ impl Widget for ScrollableWidget {
     }
 
     fn layout(&self, mut ctx: LayoutContext<'_>, constraints: Constraints) -> Vec2 {
+        ctx.layout.enable_clipping(ctx.dom);
+
         let node = ctx.dom.get_current();
         let mut canvas_size = Vec2::ZERO;
 
@@ -103,20 +105,9 @@ impl Widget for ScrollableWidget {
 
     fn paint(&self, mut ctx: PaintContext<'_>) {
         let node = ctx.dom.get_current();
-        let layout = ctx.layout.get(ctx.dom.current()).unwrap();
-
-        let should_clip = layout.rect.size().x >= 0.0 && layout.rect.size().y >= 0.0;
-
-        if should_clip {
-            ctx.paint.push_clip(layout.rect);
-        }
 
         for &child in &node.children {
             ctx.paint(child);
-        }
-
-        if should_clip {
-            ctx.paint.pop_clip();
         }
     }
 


### PR DESCRIPTION
Fixes #61.

This PR reworks yakui's clipping API to happen during layout instead of just during paint. This lets us use it during hit testing and will also let us perform paint culling.

## TODO
- [x] Update hit testing